### PR TITLE
Remove duplicate itemized versions

### DIFF
--- a/lib/mvp/bigquery.rb
+++ b/lib/mvp/bigquery.rb
@@ -210,6 +210,10 @@ class Mvp
       end
     end
 
+    def delete(entity, field, match)
+      @dataset.query("DELETE FROM forge_#{entity} WHERE #{field} = '#{match}'")
+    end
+
     def get(entity, fields)
       raise 'pass fields as an array' unless fields.is_a? Array
       @dataset.query("SELECT #{fields.join(', ')} FROM forge_#{entity}")

--- a/lib/mvp/runner.rb
+++ b/lib/mvp/runner.rb
@@ -66,6 +66,7 @@ class Mvp
           bigquery.unitemized.each do |mod|
             spinner.update(title: "Itemizing [#{mod[:slug]}]...")
             rows = itemizer.itemized(mod)
+            bigquery.delete(:itemized, :module, mod[:slug])
             bigquery.insert(:itemized, rows)
           end
           spinner.success('(OK)')


### PR DESCRIPTION
This will ensure that only the most recent version is used by the
Rangefinder tool.