### PR TITLE
Canonicalize names/sources

### DIFF
--- a/lib/mvp/bigquery.rb
+++ b/lib/mvp/bigquery.rb
@@ -208,6 +208,7 @@ class Mvp
 
     def insert(entity, data, suite = 'forge')
       return if @options[:noop]
+      return if data.empty?
 
       table    = @dataset.table("#{suite}_#{entity}")
       response = table.insert(data)
@@ -223,6 +224,10 @@ class Mvp
     def get(entity, fields)
       raise 'pass fields as an array' unless fields.is_a? Array
       @dataset.query("SELECT #{fields.join(', ')} FROM forge_#{entity}")
+    end
+
+    def module_sources()
+      get('modules', ['slug', 'source'])
     end
 
     def puppetfiles()

--- a/lib/mvp/runner.rb
+++ b/lib/mvp/runner.rb
@@ -73,26 +73,26 @@ class Mvp
           spinner.success('(OK)')
         end
 
-        if [:all, :puppetfiles].include? target
-          spinner = mkspinner("Analyzing Puppetfile module references...")
-          if pfparser.suitable?
-            bigquery.puppetfiles.each do |repo|
-              spinner.update(title: "Analyzing [#{repo[:repo_name]}/Puppetfile]...")
-              rows = pfparser.parse(repo)
-              next if rows.empty?
-              bigquery.insert(:puppetfile_usage, rows, :github)
-            end
-            spinner.success('(OK)')
-          else
-            spinner.error("(Not functional on Ruby #{RUBY_VERSION})")
-          end
-        end
-
         if [:all, :mirrors, :tables].include? target
           @options[:gcloud][:mirrors].each do |entity|
             spinner = mkspinner("Mirroring #{entity[:type]} #{entity[:name]} to BigQuery...")
             bigquery.mirror_table(entity)
             spinner.success('(OK)')
+          end
+        end
+
+        if [:all, :puppetfiles].include? target
+          spinner = mkspinner("Analyzing Puppetfile module references...")
+          if pfparser.suitable?
+            pfparser.sources = bigquery.module_sources
+            bigquery.puppetfiles.each do |repo|
+              spinner.update(title: "Analyzing [#{repo[:repo_name]}/Puppetfile]...")
+              rows = pfparser.parse(repo)
+              bigquery.insert(:puppetfile_usage, rows, :github)
+            end
+            spinner.success('(OK)')
+          else
+            spinner.error("(Not functional on Ruby #{RUBY_VERSION})")
           end
         end
 


### PR DESCRIPTION
This will try to infer the proper name for a module pulled from git
based on the repo it's pulled from. It will compare that repo against a
list of the `source` metadata from all Forge modules to identify what
the fully namespaced module name should be.

It will also better describe what programmatically calculated sources
are. Since we're doing static analysis, we can't interpolate a string
and have to just discard the value entirely.